### PR TITLE
Trying to fix the issue when int() comes as a BGP peer name

### DIFF
--- a/plugins/bgp.py
+++ b/plugins/bgp.py
@@ -27,7 +27,9 @@ def run(api, ts=False):
         # Remote AS for peer
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',remote-as]',
+            key='mikrotik.bgp.node[{name},remote-as]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem['remote-as'])
         )
@@ -35,7 +37,9 @@ def run(api, ts=False):
         # Accepted Prefixes
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',prefix-count]',
+            key='mikrotik.bgp.node[{name},prefix-count]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem['prefix-count'])
         )
@@ -43,7 +47,9 @@ def run(api, ts=False):
         # Administrative status
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',disabled]',
+            key='mikrotik.bgp.node[{name},disabled]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem['disabled'])
         )
@@ -51,7 +57,9 @@ def run(api, ts=False):
         # Established time for peer
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',uptime]',
+            key='mikrotik.bgp.node[{name},uptime]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             #value=bgpitem['uptime']
             value=zabbix_escape(time_convert(bgpitem['uptime']))
@@ -75,7 +83,9 @@ def run(api, ts=False):
 
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',state]',
+            key='mikrotik.bgp.node[{name},state]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgp_state)
         )
@@ -83,7 +93,9 @@ def run(api, ts=False):
         # Printing the comment
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',comment]',
+            key='mikrotik.bgp.node[{name},comment]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem.get('comment', ''))
         )
@@ -91,7 +103,9 @@ def run(api, ts=False):
         # Updates Received
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',updates-received]',
+            key='mikrotik.bgp.node[{name},updates-received]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem.get('updates-received'))
         )
@@ -99,7 +113,9 @@ def run(api, ts=False):
         # Updates Sent
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',updates-sent]',
+            key='mikrotik.bgp.node[{name},updates-sent]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem.get('updates-sent'))
         )
@@ -108,7 +124,9 @@ def run(api, ts=False):
         # Withdrawn Received
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',withdrawn-received]',
+            key='mikrotik.bgp.node[{name},withdrawn-received]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem.get('withdrawn-received'))
         )
@@ -116,7 +134,9 @@ def run(api, ts=False):
         # Withdrawn Sent
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[' + bgpitem['name'] + ',withdrawn-sent]',
+            key='mikrotik.bgp.node[{name},withdrawn-sent]'.format(
+                name=bgpitem['name']
+            ),
             unixtime=unixtime,
             value=zabbix_escape(bgpitem.get('withdrawn-sent'))
         )


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Sometimes the operators put the numbers as the names of BGP Peers (saying AS-NUM).
Because of this the concatenation in `plugins/bgp.py` got failed with:
```
Traceback (most recent call last):
  File "/etc/zabbix/mikrotik/zabbix.py", line 62, in <module>
    main()
  File "/etc/zabbix/mikrotik/zabbix.py", line 55, in main
    m.run(api, args.use_timestamps)
  File "/etc/zabbix/mikrotik/plugins/bgp.py", line 30, in run
    key='mikrotik.bgp.node[' + bgpitem['name'] + ',remote-as]',
TypeError: cannot concatenate 'str' and 'int' objects
```

This PR should fix that.

Should fix #1 
