### PR TITLE
Fixing github issue #3 and #4: Whitespaces handling issue and bgp error when bgp session is down

### DIFF
--- a/plugins/bgp.py
+++ b/plugins/bgp.py
@@ -23,47 +23,30 @@ def run(api, ts=False):
 
     bgpstats = api(cmd='/routing/bgp/peer/print')
 
+    # The list of BGP values to monitor
+    values_to_monitor = [
+        'remote-as',           # Remote AS for peer
+        'prefix-count',        # Accepted Prefixes
+        'disabled',            # Administrative status
+        'uptime',              # Established time for peer
+        'comment',             # Printing the comment
+        'updates-received',    # Updates Received
+        'updates-sent',        # Updates Sent
+        'withdrawn-received',  # Withdrawn Received
+        'withdrawn-sent'       # Withdrawn Sent
+    ]
+
     for bgpitem in bgpstats:
-        # Remote AS for peer
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},remote-as]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem['remote-as'])
-        )
-
-        # Accepted Prefixes
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},prefix-count]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem['prefix-count'])
-        )
-
-        # Administrative status
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},disabled]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem['disabled'])
-        )
-
-        # Established time for peer
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},uptime]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            #value=bgpitem['uptime']
-            value=zabbix_escape(time_convert(bgpitem['uptime']))
-        )
+        for val in values_to_monitor:
+            print "{host} {key}{unixtime}{value}".format(
+                host='-',
+                key='mikrotik.bgp.node["{name}","{val}"]'.format(
+                    name=bgpitem['name'],
+                    val=val
+                ),
+                unixtime=unixtime,
+                value=zabbix_escape(bgpitem.get(val, 0))
+            )
 
         # operational status
         if bgpitem['state'] == "idle":
@@ -83,60 +66,9 @@ def run(api, ts=False):
 
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.bgp.node[{name},state]'.format(
+            key='mikrotik.bgp.node["{name}","state"]'.format(
                 name=bgpitem['name']
             ),
             unixtime=unixtime,
             value=zabbix_escape(bgp_state)
-        )
-
-        # Printing the comment
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},comment]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem.get('comment', ''))
-        )
-
-        # Updates Received
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},updates-received]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem.get('updates-received'))
-        )
-
-        # Updates Sent
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},updates-sent]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem.get('updates-sent'))
-        )
-
-
-        # Withdrawn Received
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},withdrawn-received]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem.get('withdrawn-received'))
-        )
-
-        # Withdrawn Sent
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.bgp.node[{name},withdrawn-sent]'.format(
-                name=bgpitem['name']
-            ),
-            unixtime=unixtime,
-            value=zabbix_escape(bgpitem.get('withdrawn-sent'))
         )

--- a/plugins/irq.py
+++ b/plugins/irq.py
@@ -25,7 +25,7 @@ def run(api, ts=False):
     for irqitem in irqstats:
         print "{host} {key}{unixtime}{value}".format(
             host='-',
-            key='mikrotik.irq[' + irqitem.get('users').replace(",", "__") + ']',
+            key='mikrotik.irq["' + irqitem.get('users').replace(",", "__") + '"]',
             unixtime=unixtime,
             value=zabbix_escape(irqitem['count'])
         )

--- a/plugins/radius.py
+++ b/plugins/radius.py
@@ -27,44 +27,41 @@ def run(api, ts=False):
     # ({   u'acks': 263085, u'bad-requests': 0, u'naks': 11304, u'requests': 274388},)
     coastats = api(cmd='/radius/incoming/monitor', once=True)
 
+    coa_values_to_monitor = [
+        'acks',          # Acknowledged
+        'bad-requests',  # Bad Requests
+        'naks',          # Rejects
+        'requests'       # Requests
+
+    ]
+
     for coaitem in coastats:
-        # Acknowledged
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.radius-in.coa[acks]',
-            unixtime=unixtime,
-            value=zabbix_escape(coaitem['acks'])
-        )
-
-        # Bad Requests
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.radius-in.coa[bad-requests]',
-            unixtime=unixtime,
-            value=zabbix_escape(coaitem['bad-requests'])
-        )
-
-        # Rejects
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.radius-in.coa[naks]',
-            unixtime=unixtime,
-            value=zabbix_escape(coaitem['naks'])
-        )
-
-        # Requests
-        print "{host} {key}{unixtime}{value}".format(
-            host='-',
-            key='mikrotik.radius-in.coa[requests]',
-            unixtime=unixtime,
-            value=zabbix_escape(coaitem['requests'])
-        )
+        for val in coa_values_to_monitor:
+            print "{host} {key}{unixtime}{value}".format(
+                host='-',
+                key='mikrotik.radius-in.coa[{val}]'.format(
+                    val=val
+                ),
+                unixtime=unixtime,
+                value=zabbix_escape(coaitem.get(val, 0))
+            )
 
     # We need to figure out which Radius settings do we have
     radservers = api(cmd='/radius/print')
 
     # pp = pprint.PrettyPrinter(indent=4)
     # pp.pprint(radservers)
+
+    radius_values_to_monitor = [
+        'accepts',      # Accepts
+        'bad-replies',  # Bad Replies
+        'pending',      # Pending
+        'rejects',      # Rejects
+        'requests',     # Requests
+        'resends',      # Resends
+        'timeouts',     # Timeouts
+        # 'comment'
+    ]
 
     for server in radservers:
         # Lets fetch the stats for the every server
@@ -73,66 +70,10 @@ def run(api, ts=False):
         # pp.pprint(stats)
 
         for item in stats:
-            # Printing the comment
-            #print "{host} {key}{unixtime}{value}".format(
-            #    host='-',
-            #    key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',comment]',
-            #    unixtime=unixtime,
-            #    value=zabbix_escape(server.get('comment', server.get('.id')))
-            #)
-
-            # Accepts
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',accepts]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('accepts'))
-            )
-
-            # Bad Replies
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',bad-replies]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('bad-replies'))
-            )
-
-            # pending
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',pending]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('pending'))
-            )
-
-            # Rejects
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',rejects]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('rejects'))
-            )
-
-            # Requests
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',requests]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('requests'))
-            )
-
-            # Resends
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',resends]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('resends'))
-            )
-
-            # Timeouts
-            print "{host} {key}{unixtime}{value}".format(
-                host='-',
-                key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',timeouts]',
-                unixtime=unixtime,
-                value=zabbix_escape(item.get('timeouts'))
-            )
+            for val in radius_values_to_monitor:
+                print "{host} {key}{unixtime}{value}".format(
+                    host='-',
+                    key='mikrotik.radius-out.node[' + strip(server.get('.id'), '*') + ',' + val + ']',
+                    unixtime=unixtime,
+                    value=zabbix_escape(item.get(val))
+                )


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request (#3 and #4)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The code fixes an issue when script fails when BGP peer is down and there is no prefix-count key received from RouterOS.

Also it handles the keys when whitespace in the name happens.
