### PR TITLE
Releasing v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
 * Using `logging` library. `-v` up to `-vvvv` sets up the logging.
 * Added `--encoding` parameter, where you can specify the encoding. Like `ASCII`, `UTF-8` or something else (`ASCII` is the default)
 * Fixing an issue when app got crashed if BGP peer had been disabled manually
+* Adding the module which allows to track firewall counters. The rule's comment must start with `ZBX` keyword, or the rule is skipped otherwise.
+
 
 ---
 [LibrouterOS: New Auth Method]: https://librouteros.readthedocs.io/en/latest/usage.html#new-auth-method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 * Upgrading to `librouteros==2.2.0`
 * Using `logging` library. `-v` up to `-vvvv` sets up the logging.
 * Added `--encoding` parameter, where you can specify the encoding. Like `ASCII`, `UTF-8` or something else (`ASCII` is the default)
+* Fixing an issue when app got crashed if BGP peer had been disabled manually
 
 ---
 [LibrouterOS: New Auth Method]: https://librouteros.readthedocs.io/en/latest/usage.html#new-auth-method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+Changelog
+=========
+
+## 0.2.0 (2019-06-22)
+* **BREAKING**: Added `--login-method` parameter, which specifies which the logging method to use when connecting to your mikrotik.
+  Check [LibrouterOS: New Auth Method] for the details. The default method is login_plain for the firmware 6.43+.
+  Before autodetect was used, but that polluted Mikrotik's log very greatly.
+* **BREAKING**: plugins/lld_plugins's `run()` function now accepts the third parameter for doing the logging.
+* Upgrading to `librouteros==2.2.0`
+* Using `logging` library. `-v` up to `-vvvv` sets up the logging.
+* Added `--encoding` parameter, where you can specify the encoding. Like `ASCII`, `UTF-8` or something else (`ASCII` is the default)
+
+---
+[LibrouterOS: New Auth Method]: https://librouteros.readthedocs.io/en/latest/usage.html#new-auth-method

--- a/libs/loadplugins.py
+++ b/libs/loadplugins.py
@@ -5,9 +5,12 @@ The idea and the code mainly had been found at https://copyninja.info/blog/dynam
 """
 
 import os
-import sys
 import re
 import importlib
+from logging import getLogger, NullHandler
+
+LOGGER = getLogger('application')
+LOGGER.addHandler(NullHandler())
 
 
 def load_plugins(p_root_dir=os.path.dirname(__file__), p_dir='plugins'):
@@ -30,7 +33,7 @@ def load_plugins(p_root_dir=os.path.dirname(__file__), p_dir='plugins'):
     modules = []
     for plugin in plugins:
         if not plugin.startswith('.__'):
-            sys.stderr.write('Loading ' + plugin + ' from ' + os.path.join(p_root_dir, p_dir) + '\n')
+            LOGGER.debug('Loading ' + plugin + ' from ' + os.path.join(p_root_dir, p_dir) + '\n')
             modules.append(importlib.import_module(plugin, package=p_dir))
 
     return modules

--- a/lld_plugins/bgp.py
+++ b/lld_plugins/bgp.py
@@ -5,9 +5,10 @@ This module pokes Mikrotik for BGP Peers
 import json
 import time
 from libs.strings import zabbix_escape
+from logging import getLogger
 
 
-def run(api, ts=False):
+def run(api, ts=False, log=getLogger(__name__)):
     """
     Returns BGP LLD JSON
     :param api: initialized librouteros' connect()

--- a/lld_plugins/firewall.py
+++ b/lld_plugins/firewall.py
@@ -1,0 +1,77 @@
+# -*- coding: UTF-8 -*-
+"""
+This module pokes Mikrotik for Firewall Rules
+"""
+import json
+import time
+import pprint
+from string import strip
+from libs.strings import zabbix_escape
+from logging import getLogger
+
+
+def run(api, ts=False, log=getLogger(__name__)):
+    """
+    Returns Firewall Rules LLD JSON
+    :param api: initialized librouteros' connect()
+    :param ts: Use timestamps
+    :return:
+    """
+    pp = pprint.PrettyPrinter(indent=4)
+
+    if ts:
+        unixtime = " {time} ".format(
+            time=int(time.time())
+        )
+    else:
+        unixtime = " "
+
+    # Fetch firewall stats
+    tables = [
+        "filter",
+        "nat",
+        "mangle",
+        "raw"
+    ]
+
+    lld = []
+
+    for t in tables:
+        log.debug("Processing {table} firewall table".format(
+            table=t
+        ))
+
+        cmd = '/ip/firewall/{table}/print'.format(table=t)
+
+        log.debug(pp.pformat(cmd))
+
+        stats = api(
+            cmd=cmd,
+            stats=True
+        )
+
+        for rule in stats:
+            # We don't want ALL the rules here. We want only those, which has ZBX at the beginning of the comment
+            comment = rule.get('comment', '')
+            if not comment.startswith('ZBX'):
+                continue
+
+            lld.append(
+                {
+                    '{#MTIK_FW_RULE_ID}': t + '_' + strip(rule.get('.id'), '*'),
+                    '{#MTIK_FW_RULE_COMMENT}': rule.get('comment', rule.get('.id'))
+                }
+            )
+
+    # Composing JSON to return
+    json_data = {
+        'data': lld
+    }
+
+    # Return JSON
+    print "{host} {key}{unixtime}{value}".format(
+        host='-',
+        key='mikrotik.firewall.discovery',
+        unixtime=unixtime,
+        value=zabbix_escape(json.dumps(json_data))
+    )

--- a/lld_plugins/irq.py
+++ b/lld_plugins/irq.py
@@ -5,9 +5,10 @@ This module pokes Mikrotik for IRQ Peers
 import json
 import time
 from libs.strings import zabbix_escape
+from logging import getLogger
 
 
-def run(api, ts=False):
+def run(api, ts=False, log=getLogger(__name__)):
     """
     Returns IRQ LLD JSON
     :param api: initialized librouteros' connect()

--- a/lld_plugins/radius.py
+++ b/lld_plugins/radius.py
@@ -6,9 +6,10 @@ import json
 import time
 from string import strip
 from libs.strings import zabbix_escape
+from logging import getLogger
 
 
-def run(api, ts=False):
+def run(api, ts=False, log=getLogger(__name__)):
     """
     Returns Radius LLD JSON
     :param api: initialized librouteros' connect()

--- a/plugins/bgp.py
+++ b/plugins/bgp.py
@@ -49,18 +49,21 @@ def run(api, ts=False, log=getLogger(__name__)):
                 value=zabbix_escape(bgpitem.get(val, 0))
             )
 
+        state = bgpitem.get('state', 'disabled')
+        uptime = bgpitem.get('uptime', '0s')
+
         # operational status
-        if bgpitem['state'] == "idle":
+        if state == "idle":
             bgp_state = 1
-        elif bgpitem['state'] == "connect":
+        elif state == "connect":
             bgp_state = 2
-        elif bgpitem['state'] == "active":
+        elif state == "active":
             bgp_state = 3
-        elif bgpitem['state'] == "opensent":
+        elif state == "opensent":
             bgp_state = 4
-        elif bgpitem['state'] == "openconfirm":
+        elif state == "openconfirm":
             bgp_state = 5
-        elif bgpitem['state'] == "established":
+        elif state == "established":
             bgp_state = 6
         else:
             bgp_state = 0
@@ -81,6 +84,6 @@ def run(api, ts=False, log=getLogger(__name__)):
                 name=bgpitem['name']
             ),
             unixtime=unixtime,
-            #value=bgpitem['uptime']
-            value=zabbix_escape(time_convert(bgpitem['uptime']))
+            # value=bgpitem['uptime']
+            value=zabbix_escape(time_convert(uptime))
         )

--- a/plugins/bgp.py
+++ b/plugins/bgp.py
@@ -5,9 +5,10 @@ This module pokes Mikrotik for BGP Counters
 import time
 from libs.time import time_convert
 from libs.strings import zabbix_escape
+from logging import getLogger
 
 
-def run(api, ts=False):
+def run(api, ts=False, log=getLogger(__name__)):
     """
     Returns BGP Counters
     :param api: initialized librouteros' connect()

--- a/plugins/firewall.py
+++ b/plugins/firewall.py
@@ -1,0 +1,97 @@
+# -*- coding: UTF-8 -*-
+# /ip firewall filter print stats where comment ~ ".*Hotspot.*AUTH"
+# /ip firewall filter print stats where comment ~ ".*Hotspot.*ACC"
+# /ip firewall filter print stats where comment ~ ".*DHCP.*AUTH"
+# /ip firewall filter print stats where comment ~ ".*DHCP.*ACC"
+"""
+This module pokes Mikrotik for Firewall Counters
+"""
+import time
+import pprint
+
+from string import strip
+from libs.strings import zabbix_escape
+from logging import getLogger
+
+
+def run(api, ts=False, log=getLogger(__name__)):
+    """
+    Returns firewall counters
+    :param api: initialized librouteros' connect()
+    :param ts: Use timestamps
+    :return:
+    """
+    pp = pprint.PrettyPrinter(indent=4)
+
+    if ts:
+        unixtime = " {time} ".format(
+            time=int(time.time())
+        )
+    else:
+        unixtime = " "
+
+    # Fetch firewall stats
+    tables = [
+        "filter",
+        "nat",
+        "mangle",
+        "raw"
+    ]
+
+    for t in tables:
+        log.debug("Processing {table} firewall table".format(
+            table=t
+        ))
+
+        cmd = '/ip/firewall/{table}/print'.format(table=t)
+
+        log.debug(pp.pformat(cmd))
+
+        stats = api(
+            cmd=cmd,
+            stats=True
+        )
+
+        metrics_to_monitor = [
+            'bytes',
+            'packets',
+            'disabled',
+            # 'comment'
+        ]
+
+        for rule in stats:
+            """
+            {   
+                u'.id': u'*3D',
+                u'action': u'accept',
+                u'bytes': 113970290691,
+                u'chain': u'forward',
+                u'comment': u'Allow Incoming from CORE to WAN',
+                u'disabled': False,
+                u'dynamic': False,
+                u'in-interface-list': u'CORE',
+                u'invalid': False,
+                u'log': False,
+                u'log-prefix': u'',
+                u'out-interface-list': u'WAN',
+                u'packets': 102508788
+            }
+            """
+
+            # We don't want ALL the rules here. We want only those, which has ZBX at the beginning of the comment
+            comment = rule.get('comment', '')
+            if not comment.startswith('ZBX'):
+                continue
+
+            log.info(pp.pformat(comment))
+            for metric in metrics_to_monitor:
+                print "{host} \"{key}\"{unixtime}{value}".format(
+                    host='-',
+                    key='mikrotik.firewall[{table}_{id},{metric}]'.format(
+                        table=t,
+                        id=strip(rule.get('.id'), '*'),
+                        metric=metric
+                    ),
+                    unixtime=unixtime,
+                    value=zabbix_escape(rule.get(metric))
+                )

--- a/plugins/irq.py
+++ b/plugins/irq.py
@@ -4,9 +4,10 @@ This module pokes Mikrotik for IRQ Counters
 """
 import time
 from libs.strings import zabbix_escape
+from logging import getLogger
 
 
-def run(api, ts=False):
+def run(api, ts=False, log=getLogger(__name__)):
     """
     Returns IRQ Counters
     :param api: initialized librouteros' connect()

--- a/plugins/radius.py
+++ b/plugins/radius.py
@@ -7,9 +7,10 @@ import time
 
 from string import strip
 from libs.strings import zabbix_escape
+from logging import getLogger
 
 
-def run(api, ts=False):
+def run(api, ts=False, log=getLogger(__name__)):
     """
     Returns Radius Counters
     :param api: initialized librouteros' connect()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-librouteros==2.1.0
+librouteros==2.2.0


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
* **BREAKING**: Added `--login-method` parameter, which specifies which the logging method to use when connecting to your mikrotik.
  Check [LibrouterOS: New Auth Method] for the details. The default method is login_plain for the firmware 6.43+.
  Before autodetect was used, but that polluted Mikrotik's log very greatly.
* **BREAKING**: plugins/lld_plugins's `run()` function now accepts the third parameter for doing the logging.
* Upgrading to `librouteros==2.2.0`
* Using `logging` library. `-v` up to `-vvvv` sets up the logging.
* Added `--encoding` parameter, where you can specify the encoding. Like `ASCII`, `UTF-8` or something else (`ASCII` is the default)
* Fixes #8 